### PR TITLE
Transition probabilities

### DIFF
--- a/Place.py
+++ b/Place.py
@@ -6,12 +6,18 @@ from Person import Person
 
 class Place:
 
-    def __init__(self, place_info):
+    def __init__(self, place_info,places_group,place_id):
         self.population = set()
         self.place_info = place_info  # (40.760265, -73.989105, 'Italian', '217', '291', 'Ristorante Da Rosina')
         self.time_to_recover = 14
         self.total_infected_number = 0
         self.immune_population = set()
+        # if places_group and place_id are both None, then there is no transition probabilities estimated
+        try:
+            place_transitions = places_group.get_group(place_id)
+            self.transitions = (place_transitions['venue2'].value_counts()/len(place_transitions)).to_dict()
+        except (KeyError, AttributeError):
+            self.transitions = dict()
 
     def get_population(self):
         return self.population

--- a/PlaceNetSim_v2.py
+++ b/PlaceNetSim_v2.py
@@ -31,6 +31,9 @@ class PlaceNetSim:
 		#read venue (node) data 
 		# node_data = {}
 		self.pos_dict = {} #will be used to draw the nodes in the graph with geographic topology
+		#CURRENTLY the following two lines are commented out but they are needed if we are to use mobility 
+		#self.df_transitions = pd.read_csv('./shared_data/newyork_placenet_transitions.csv', error_bad_lines=False)
+		#places_group = self.df_transitions.groupby('venue1')
 		for l in open('./shared_data/newyork_anon_locationData_newcrawl.txt'):
 			splits = l.split('*;*')
 			venue_id = int(splits[0])
@@ -41,7 +44,7 @@ class PlaceNetSim:
 			self.NYC_graph.nodes[venue_id]['info'] = venue_info #(40.760265, -73.989105, 'Italian', '217', '291', 'Ristorante Da Rosina')
 
 			#initialise placee and within place, population information 
-			self.places[venue_id] = Place(venue_info)
+			self.places[venue_id] = Place(venue_info, None, None) # if we want probababilistic transitions we should set places_group & venue_id
 
 			#this will be used for drawing the network
 			self.pos_dict[venue_id] = (venue_info[1], venue_info[0])


### PR DESCRIPTION
I created `transitions` attribute for a `Place` object that is a dictionary with the transition probability from this place to others in the dataset. Currently it includes only transitions observed, but we should include a 'teleport'-like operation for venues that have not been visited from this place. This can either be part of the initialization phase or the actual simulation phase. 